### PR TITLE
Added Hudson Rock to 2025

### DIFF
--- a/2025.md
+++ b/2025.md
@@ -6,3 +6,4 @@
 - https://noimosiny.com/
 - https://github.com/JackJuly/linkook
 - https://github.com/stanfordio/truthbrush
+- [Hudson Rock Free Infostealer Intelligence Toolset](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools)


### PR DESCRIPTION
Free cybercrime intelligence toolset to check if an email address, username, or domain was exposed in an Infostealer malware attack.